### PR TITLE
Add ArtEmbedder desktop embedding tool

### DIFF
--- a/ArtEmbedder/README.md
+++ b/ArtEmbedder/README.md
@@ -1,0 +1,21 @@
+# ArtEmbedder
+
+A desktop tool for embedding a single art image into multiple scene images automatically.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python src/main.py
+```
+
+1. Drag multiple scene images into the left list.
+2. Drag one art image into the right list.
+3. Adjust feather radius and perspective epsilon if needed.
+4. Click **开始合成** to start batch processing.
+5. Click **打开输出目录** to view results. Logs are saved to `output/log.csv`.

--- a/ArtEmbedder/requirements.txt
+++ b/ArtEmbedder/requirements.txt
@@ -1,0 +1,5 @@
+PyQt5
+opencv-python
+numpy
+pandas
+tqdm

--- a/ArtEmbedder/src/config.py
+++ b/ArtEmbedder/src/config.py
@@ -1,0 +1,5 @@
+INPUT_DIR = "input/"
+OUTPUT_DIR = "output/"
+FEATHER_RADIUS = 5
+PERSPECTIVE_EPS = 0.02
+LOG_PATH = "output/log.csv"

--- a/ArtEmbedder/src/frame_detector.py
+++ b/ArtEmbedder/src/frame_detector.py
@@ -1,0 +1,41 @@
+import cv2
+import numpy as np
+from typing import Dict
+import config
+
+
+def detect_frame_corners(img: np.ndarray, params: Dict) -> np.ndarray:
+    """Detect frame corners from image and return 4x2 array of points."""
+    eps = params.get("PERSPECTIVE_EPS", config.PERSPECTIVE_EPS)
+
+    # Segment possible frame regions
+    lab = cv2.cvtColor(img, cv2.COLOR_BGR2Lab)
+    L, a, b = cv2.split(lab)
+    _, mask_white = cv2.threshold(L, 200, 255, cv2.THRESH_BINARY)
+
+    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+    mask_green = cv2.inRange(hsv, (40, 40, 40), (80, 255, 255))
+    mask_blue = cv2.inRange(hsv, (100, 40, 40), (140, 255, 255))
+
+    mask = cv2.bitwise_or(mask_white, cv2.bitwise_or(mask_green, mask_blue))
+
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        raise ValueError("No frame detected")
+
+    c = max(contours, key=cv2.contourArea)
+    peri = cv2.arcLength(c, True)
+    approx = cv2.approxPolyDP(c, eps * peri, True)
+
+    if len(approx) != 4:
+        rect = cv2.minAreaRect(c)
+        box = cv2.boxPoints(rect)
+    else:
+        box = approx.reshape(-1, 2)
+
+    center = np.mean(box, axis=0)
+    def angle(p):
+        return np.arctan2(p[1] - center[1], p[0] - center[0])
+
+    box_sorted = np.array(sorted(box, key=angle), dtype=np.float32)
+    return box_sorted

--- a/ArtEmbedder/src/logger.py
+++ b/ArtEmbedder/src/logger.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import pandas as pd
+import config
+
+
+def init_logger(path: str) -> None:
+    """Create log file with headers if not exists."""
+    columns = ["scene", "art", "status", "W_t", "H_t", "dx", "dy", "error"]
+    if not Path(path).exists():
+        pd.DataFrame(columns=columns).to_csv(path, index=False)
+
+
+def log_entry(scene: str, art: str, status: str, params: dict) -> None:
+    """Append one log line to csv."""
+    data = {
+        "scene": scene,
+        "art": art,
+        "status": status,
+        "W_t": params.get("W_t", ""),
+        "H_t": params.get("H_t", ""),
+        "dx": params.get("dx", ""),
+        "dy": params.get("dy", ""),
+        "error": params.get("error", ""),
+    }
+    df = pd.DataFrame([data])
+    header = not Path(config.LOG_PATH).exists()
+    df.to_csv(config.LOG_PATH, mode="a", header=header, index=False)

--- a/ArtEmbedder/src/main.py
+++ b/ArtEmbedder/src/main.py
@@ -1,0 +1,10 @@
+import sys
+from PyQt5.QtWidgets import QApplication
+from ui import MainWindow
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec_())

--- a/ArtEmbedder/src/pipeline.py
+++ b/ArtEmbedder/src/pipeline.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from typing import List, Dict
+import cv2
+import config
+from frame_detector import detect_frame_corners
+from transformer import compute_transform, warp_and_blend
+from logger import init_logger, log_entry
+
+
+def run_batch(scene_paths: List[str], art_path: str, params: Dict, progress_cb):
+    art = cv2.imread(art_path)
+    if art is None:
+        raise ValueError(f"Cannot read art image: {art_path}")
+    W_s, H_s = art.shape[1], art.shape[0]
+    init_logger(config.LOG_PATH)
+    for idx, canvas_path in enumerate(scene_paths, 1):
+        try:
+            canvas = cv2.imread(canvas_path)
+            if canvas is None:
+                raise ValueError(f"Cannot read scene image: {canvas_path}")
+            pts = detect_frame_corners(canvas, params)
+            H_mat, W_t, H_t, dx, dy = compute_transform(W_s, H_s, pts, params)
+            result = warp_and_blend(canvas, art, H_mat, params)
+            out_name = f"{Path(art_path).stem}_{Path(canvas_path).stem}.jpg"
+            out_path = Path(config.OUTPUT_DIR) / out_name
+            cv2.imwrite(str(out_path), result)
+            log_entry(Path(canvas_path).name, Path(art_path).name, "OK", {"W_t": W_t, "H_t": H_t, "dx": dx, "dy": dy})
+            progress_cb(idx, len(scene_paths), f"{out_name} OK")
+        except Exception as e:
+            log_entry(Path(canvas_path).name, Path(art_path).name, "ERROR", {"error": str(e)})
+            progress_cb(idx, len(scene_paths), f"{Path(canvas_path).name} ERROR: {e}")

--- a/ArtEmbedder/src/transformer.py
+++ b/ArtEmbedder/src/transformer.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+import numpy as np
+import cv2
+from typing import Tuple, Dict
+import config
+
+
+def compute_transform(W_s: int, H_s: int, dst_pts: np.ndarray, params: Dict) -> Tuple[np.ndarray, float, float, float, float]:
+    """Compute perspective transform for embedding art into dst_pts."""
+    xs = dst_pts[:, 0]
+    ys = dst_pts[:, 1]
+    W_t = float(xs.max() - xs.min())
+    H_t = float(ys.max() - ys.min())
+
+    s = min(W_t / W_s, H_t / H_s)
+    W_p = W_s * s
+    H_p = H_s * s
+    dx = (W_t - W_p) / 2.0
+    dy = (H_t - H_p) / 2.0
+
+    alpha = dx / W_t if W_t else 0
+    beta = dy / H_t if H_t else 0
+
+    Q = []
+    for i in range(4):
+        p_i = dst_pts[i]
+        p_next = dst_pts[(i + 1) % 4]
+        p_prev = dst_pts[(i - 1) % 4]
+        q = p_i + alpha * (p_next - p_i) + beta * (p_prev - p_i)
+        Q.append(q)
+    Q = np.array(Q, dtype=np.float32)
+
+    src_pts = np.array([[0, 0], [W_s, 0], [W_s, H_s], [0, H_s]], dtype=np.float32)
+    H_mat = cv2.getPerspectiveTransform(src_pts, Q)
+    return H_mat, W_t, H_t, dx, dy
+
+
+def warp_and_blend(canvas: np.ndarray, art: np.ndarray, H: np.ndarray, params: Dict) -> np.ndarray:
+    """Warp art using matrix H and blend into canvas."""
+    h_c, w_c = canvas.shape[:2]
+
+    warped = cv2.warpPerspective(art, H, (w_c, h_c))
+
+    src_pts = np.array([[0, 0], [art.shape[1], 0], [art.shape[1], art.shape[0]], [0, art.shape[0]]], dtype=np.float32)
+    dst_pts_embedded = cv2.perspectiveTransform(src_pts.reshape(-1, 1, 2), H).reshape(4, 2)
+
+    mask = np.zeros((h_c, w_c), dtype=np.uint8)
+    cv2.fillConvexPoly(mask, dst_pts_embedded.astype(np.int32), 255)
+
+    radius = params.get("FEATHER_RADIUS", config.FEATHER_RADIUS)
+    ksize = max(1, int(radius) * 2 + 1)
+    mask_blur = cv2.GaussianBlur(mask, (ksize, ksize), 0)
+    mask_norm = mask_blur.astype(np.float32) / 255.0
+
+    result = canvas.copy()
+    for c in range(3):
+        result[:, :, c] = warped[:, :, c] * mask_norm + canvas[:, :, c] * (1 - mask_norm)
+
+    return result

--- a/ArtEmbedder/src/ui.py
+++ b/ArtEmbedder/src/ui.py
@@ -1,0 +1,127 @@
+import os
+import threading
+from pathlib import Path
+from typing import List
+
+from PyQt5.QtWidgets import (
+    QMainWindow, QWidget, QListWidget, QVBoxLayout, QHBoxLayout,
+    QGroupBox, QSpinBox, QDoubleSpinBox, QPushButton, QTextEdit,
+    QProgressBar, QApplication, QLabel
+)
+from PyQt5.QtCore import Qt, QUrl
+from PyQt5.QtGui import QDragEnterEvent, QDropEvent
+from PyQt5.Qt import QDesktopServices
+
+import config
+import pipeline
+
+
+class DropListWidget(QListWidget):
+    def __init__(self, single: bool = False):
+        super().__init__()
+        self.setAcceptDrops(True)
+        self.single = single
+
+    def dragEnterEvent(self, event: QDragEnterEvent):
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+        else:
+            super().dragEnterEvent(event)
+
+    def dropEvent(self, event: QDropEvent):
+        if event.mimeData().hasUrls():
+            if self.single:
+                self.clear()
+            for url in event.mimeData().urls():
+                path = url.toLocalFile()
+                if os.path.isfile(path):
+                    if self.single and self.count() > 0:
+                        self.takeItem(0)
+                    self.addItem(path)
+            event.acceptProposedAction()
+        else:
+            super().dropEvent(event)
+
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("画芯自动嵌入工具")
+        self.resize(800, 600)
+        self._setup_ui()
+
+    def _setup_ui(self):
+        central = QWidget()
+        self.setCentralWidget(central)
+
+        main_layout = QHBoxLayout()
+        central.setLayout(main_layout)
+
+        # Scene list and art list
+        self.scene_list = DropListWidget()
+        self.art_list = DropListWidget(single=True)
+        main_layout.addWidget(self.scene_list)
+        main_layout.addWidget(self.art_list)
+
+        # Right side layout for params and controls
+        right_layout = QVBoxLayout()
+        main_layout.addLayout(right_layout)
+
+        param_group = QGroupBox("参数")
+        param_layout = QVBoxLayout()
+        param_group.setLayout(param_layout)
+        right_layout.addWidget(param_group)
+
+        self.feather_spin = QSpinBox()
+        self.feather_spin.setRange(0, 50)
+        self.feather_spin.setValue(config.FEATHER_RADIUS)
+        self.eps_spin = QDoubleSpinBox()
+        self.eps_spin.setRange(0.0, 1.0)
+        self.eps_spin.setSingleStep(0.01)
+        self.eps_spin.setValue(config.PERSPECTIVE_EPS)
+
+        param_layout.addWidget(QLabel("羽化半径"))
+        param_layout.addWidget(self.feather_spin)
+        param_layout.addWidget(QLabel("透视精度 eps"))
+        param_layout.addWidget(self.eps_spin)
+
+        ctrl_layout = QHBoxLayout()
+        right_layout.addLayout(ctrl_layout)
+
+        self.start_btn = QPushButton("开始合成")
+        self.stop_btn = QPushButton("停止")
+        self.open_btn = QPushButton("打开输出目录")
+        ctrl_layout.addWidget(self.start_btn)
+        ctrl_layout.addWidget(self.stop_btn)
+        ctrl_layout.addWidget(self.open_btn)
+
+        self.progress = QProgressBar()
+        self.log_view = QTextEdit()
+        self.log_view.setReadOnly(True)
+        right_layout.addWidget(self.progress)
+        right_layout.addWidget(self.log_view)
+
+        self.start_btn.clicked.connect(self.start_process)
+        self.open_btn.clicked.connect(self.open_output)
+
+    def open_output(self):
+        QDesktopServices.openUrl(QUrl.fromLocalFile(str(Path(config.OUTPUT_DIR).absolute())))
+
+    def start_process(self):
+        scene_paths = [self.scene_list.item(i).text() for i in range(self.scene_list.count())]
+        art_path = self.art_list.item(0).text() if self.art_list.count() > 0 else None
+        if not scene_paths or not art_path:
+            self.log_view.append("Please drag in scene images and one art image.")
+            return
+        params = {
+            "FEATHER_RADIUS": self.feather_spin.value(),
+            "PERSPECTIVE_EPS": self.eps_spin.value()
+        }
+        thread = threading.Thread(target=pipeline.run_batch, args=(scene_paths, art_path, params, self.progress_cb))
+        thread.start()
+
+    def progress_cb(self, idx: int, total: int, message: str):
+        self.progress.setMaximum(total)
+        self.progress.setValue(idx)
+        self.log_view.append(message)
+


### PR DESCRIPTION
## Summary
- add `ArtEmbedder` project with Qt interface for batch art embedding
- implement frame detection, transformation, pipeline and logging
- provide config constants and requirements
- document install and usage instructions

## Testing
- `python -m py_compile ArtEmbedder/src/*.py`
- `python ArtEmbedder/src/main.py` *(fails: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_684a691a57d88330a9d6d88cc4d154b0